### PR TITLE
Add battery refresh scheduling and alerts

### DIFF
--- a/IKEA-window-blind-driver-code
+++ b/IKEA-window-blind-driver-code
@@ -41,6 +41,8 @@ metadata {
 	capability "Switch Level"
         capability "Battery"
 
+        attribute "batteryAlert", "string"
+
         command "pause"
         command "hardOpen"
         
@@ -59,6 +61,8 @@ metadata {
                 input name: "debugOutput", type: "bool", title: "Enable debug logging?", defaultValue: true
                 input name: "descTextOutput", type: "bool", title: "Enable descriptionText logging?", defaultValue: true
                 input name: "autoRefreshHours", type: "number", title: "Periodic refresh interval (hours)", defaultValue: 3, range: "1..24"
+                input name: "batteryRefreshHours", type: "number", title: "Battery refresh interval (hours)", defaultValue: 6, range: "1..24"
+                input name: "lowBatteryThreshold", type: "number", title: "Low battery notification threshold (%)", defaultValue: 20, range: "1..100"
         }
   
 }
@@ -106,7 +110,9 @@ def parse(String description) {
         } 
         if (descMap?.clusterInt == CLUSTER_BATTERY_LEVEL && descMap.value) {
             if (debugOutput) log.debug "attr: ${descMap?.attrInt}, value: ${descMap?.value}, descValue: ${Integer.parseInt(descMap.value, 16)}"
-            sendEvent(name: "battery", value: Integer.parseInt(descMap.value, 16), unit: "%")
+            def bat = Integer.parseInt(descMap.value, 16)
+            sendEvent(name: "battery", value: bat, unit: "%")
+            checkBatteryThreshold(bat)
         }
     }
 }
@@ -176,6 +182,22 @@ def verifyMovement() {
     }
 }
 
+def checkBatteryThreshold(val) {
+    def threshold = lowBatteryThreshold ?: 20
+    if (val < threshold) {
+        if (!state.batteryNotified) {
+            if (descTextOutput) log.warn "Battery level ${val}% is below threshold ${threshold}%"
+            sendEvent(name: "batteryAlert", value: "low")
+            state.batteryNotified = true
+        }
+    } else {
+        if (state.batteryNotified) {
+            sendEvent(name: "batteryAlert", value: "ok")
+            state.batteryNotified = false
+        }
+    }
+}
+
 def close() {
     if (descTextOutput) log.info "close()"
     runIn(5, refresh)
@@ -234,11 +256,16 @@ def pause() {
 
 def refresh() {
     if (descTextOutput) log.info "refresh()"
-    
+
     def cmds
-    cmds = zigbee.readAttribute(CLUSTER_WINDOW_COVERING, ATTRIBUTE_POSITION_LIFT) + zigbee.readAttribute(CLUSTER_BATTERY_LEVEL, 0x0021) 
+    cmds = zigbee.readAttribute(CLUSTER_WINDOW_COVERING, ATTRIBUTE_POSITION_LIFT) + zigbee.readAttribute(CLUSTER_BATTERY_LEVEL, 0x0021)
 
     return cmds
+}
+
+def refreshBattery() {
+    if (descTextOutput) log.info "refreshBattery()"
+    zigbee.readAttribute(CLUSTER_BATTERY_LEVEL, 0x0021)
 }
 
 def configure() {
@@ -260,7 +287,10 @@ def updated() {
         unschedule()
         def hours = autoRefreshHours ?: 3
         schedule("0 0 */${hours} * * ?", refresh)
+        def battHours = batteryRefreshHours ?: 6
+        schedule("0 15 */${battHours} * * ?", refreshBattery)
         refresh()
+        refreshBattery()
         if (debugOutput) runIn(1800,logsOff)
 }
 

--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ This repository provides a Hubitat driver for controlling IKEA FYRTUR and TREDAN
 ## Usage
 - Use the provided commands to open, close, pause, or set the position of the blinds.
 - The driver includes periodic refresh and battery reporting.
+- Configurable battery refresh interval and low battery notifications.
 
 This code is distributed under the Apache 2.0 license as noted in the driver header.

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,9 +1,9 @@
 {
   "packageName": "IKEA Window Blinds",
   "author": "Wayne Man",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "minimumHEVersion": "2.1.9",
-  "dateReleased": "2020-09-09",
+  "dateReleased": "2025-06-14",
   "drivers": [
     {
       "id": "69d97ae9-b9ab-4e4d-be4f-5f3b3162e147",


### PR DESCRIPTION
## Summary
- add new preferences for battery refresh interval and low battery threshold
- generate battery alerts when battery level drops below the configured threshold
- schedule separate battery refresh polling
- bump package version to 0.2.0
- document new feature in README

## Testing
- `groovyc` not available, no tests run

------
https://chatgpt.com/codex/tasks/task_e_684d66a59458832c825d4b4f0666f394